### PR TITLE
✨Add:コンポーネントのテンプレートに補完を追加

### DIFF
--- a/first-app/src/app/housing-location/housing-location.component.ts
+++ b/first-app/src/app/housing-location/housing-location.component.ts
@@ -7,9 +7,11 @@ import { HousingLocation } from '../housinglocation';
   standalone: true,
   imports: [CommonModule],
   template: `
-    <p>
-      housing-location works!
-    </p>
+  <section class="listing">
+    <img class="listing-photo" [src]="housingLocation.photo" alt="Exterior photo of {{housingLocation.name}}">
+    <h2 class="listing-heading">{{ housingLocation.name }}</h2>
+    <p class="listing-location">{{ housingLocation.city}}, {{housingLocation.state }}</p>
+  </section>
   `,
   styleUrl: './housing-location.component.css'
 })


### PR DESCRIPTION
https://angular.jp/tutorial/first-app/first-app-lesson-07

### ここで学べること
・Angularのテンプレート構文（プロパティバインディングと補間バインディング）を使用。
・アプリケーションは HousingLocationComponent テンプレートに補間された値を表示します。
・アプリケーションは住宅の位置データをブラウザにレンダリングします。

### プロパティバインディング
https://qiita.com/Momo_T/items/a68b491ec1f3445ddee9
・Angularでは、プロパティバインディングを使用して、コンポーネントのプロパティ（JavaScript側の値）をHTML要素の属性に動的に結びつける（バインド）ことができます。
使い方：HTMLテンプレート内で角括弧 [] を用いる

・具体例: housingLocation.photo を <img> タグの src 属性にバインドする
ここでの例では、housingLocation というオブジェクトの photo プロパティ(画像のURLが格納されている)があり、その値を <img> タグの src 属性にバインドしています。
```
<img class="listing-photo" [src]="housingLocation.photo">
```

### 補間バインディング
補間は、コンポーネントのプロパティをテンプレート内のテキストとして表示するために使用されます。
使い方：二重中括弧 {{ }} を使用して行われます。

```
alt="Exterior photo of {{housingLocation.name}}"
<h2 class="listing-heading">{{ housingLocation.name }}</h2>
<p class="listing-location">{{ housingLocation.city}}, {{housingLocation.state }}</p>
```
ここでの {{housingLocation.name}}, {{housingLocation.city}}, および {{housingLocation.state}} は、それぞれ housingLocation オブジェクトの name, city, と state プロパティの現在値をテキストとして表示します。例えば、housingLocation.name が "Sunny Apartments" であれば、h2 タグ内に "Sunny Apartments" が表示されます。


### alt 属性での補間の使用
alt 属性で補間が使われているのは、画像が正しくロードされなかった場合や、視覚障害を持つユーザーがスクリーンリーダーを使用している場合に、画像の説明を提供するためです。{{housingLocation.name}} を使用することで、その場所の名前を動的に alt テキストに挿入しています。